### PR TITLE
Add user profile pages

### DIFF
--- a/Yordanew/Client/Pages/Profile/Edit.vue
+++ b/Yordanew/Client/Pages/Profile/Edit.vue
@@ -1,0 +1,43 @@
+<script setup>
+import Layout from "../../Layout.vue";
+import { router, usePage, Link } from "@inertiajs/vue3";
+import { reactive, computed } from "vue";
+
+const user = usePage().props.user
+const errors = computed(() => usePage().props.errors)
+
+const state = reactive({
+  displayName: user.displayName ?? ""
+})
+
+function submit(event) {
+  router.post('/profile/edit', event.data, { forceFormData: true })
+}
+</script>
+
+<template>
+  <Layout>
+    <template #top-right>
+      <Link href="/profile">
+        <UButton variant="soft" color="error">Отменить</UButton>
+      </Link>
+    </template>
+
+    <UForm :state @submit="submit" class="flex flex-col gap-2 max-w-md mx-auto">
+      <span class="font-yordan text-3xl text-center w-full">Редактировать профиль</span>
+
+      <UFormField name="displayName" label="Отображаемое имя" :error="errors?.displayName">
+        <UInput v-model="state.displayName" class="w-full" />
+      </UFormField>
+
+      <UFormField name="avatar" label="Аватар">
+        <UInput type="file" name="avatar" />
+      </UFormField>
+
+      <UButton type="submit" class="w-full" variant="soft" color="success">Сохранить</UButton>
+    </UForm>
+  </Layout>
+</template>
+
+<style scoped>
+</style>

--- a/Yordanew/Client/Pages/Profile/Index.vue
+++ b/Yordanew/Client/Pages/Profile/Index.vue
@@ -1,0 +1,36 @@
+<script setup>
+import Layout from "../../Layout.vue";
+import { Link, usePage } from "@inertiajs/vue3";
+
+const user = usePage().props.user
+const languages = usePage().props.languages
+</script>
+
+<template>
+  <Layout>
+    <template #top-right>
+      <Link href="/profile/edit">
+        <UButton variant="soft" color="primary">Редактировать</UButton>
+      </Link>
+    </template>
+
+    <div class="flex flex-col items-center gap-2">
+      <UAvatar size="xl" :src="`/uploaded-files/avatars/${user.id}`" />
+      <span class="text-2xl">{{ user.displayName ?? user.userName }}</span>
+    </div>
+
+    <div class="mt-4 flex flex-col gap-2 items-stretch w-full">
+      <UCard variant="soft" v-for="language in languages" :key="language.id">
+        <template #header>
+          <Link :href="`/languages/${language.id}`">
+            <UButton variant="link" color="primary" class="text-xl">{{ language.name }}</UButton>
+          </Link>
+        </template>
+        <div class="line-clamp-5" v-html="language.description"></div>
+      </UCard>
+    </div>
+  </Layout>
+</template>
+
+<style scoped>
+</style>

--- a/Yordanew/Client/Pages/Profile/View.vue
+++ b/Yordanew/Client/Pages/Profile/View.vue
@@ -1,0 +1,30 @@
+<script setup>
+import Layout from "../../Layout.vue";
+import { Link, usePage } from "@inertiajs/vue3";
+
+const user = usePage().props.user
+const languages = usePage().props.languages
+</script>
+
+<template>
+  <Layout>
+    <div class="flex flex-col items-center gap-2">
+      <UAvatar size="xl" :src="`/uploaded-files/avatars/${user.id}`" />
+      <span class="text-2xl">{{ user.displayName ?? user.userName }}</span>
+    </div>
+
+    <div class="mt-4 flex flex-col gap-2 items-stretch w-full">
+      <UCard variant="soft" v-for="language in languages" :key="language.id">
+        <template #header>
+          <Link :href="`/languages/${language.id}`">
+            <UButton variant="link" color="primary" class="text-xl">{{ language.name }}</UButton>
+          </Link>
+        </template>
+        <div class="line-clamp-5" v-html="language.description"></div>
+      </UCard>
+    </div>
+  </Layout>
+</template>
+
+<style scoped>
+</style>

--- a/Yordanew/Controllers/ProfileController.cs
+++ b/Yordanew/Controllers/ProfileController.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+using InertiaCore;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Yordanew.Domain.Entity;
+using Yordanew.Dtos;
+using Yordanew.Models;
+using Yordanew.Services;
+
+namespace Yordanew.Controllers;
+
+public class ProfileController(
+    UserManager<AppUser> userManager,
+    LanguageService languageService,
+    FileService fileService
+) : Controller {
+    [Authorize]
+    [HttpGet("/profile")]
+    public async Task<IActionResult> Index() {
+        var user = await GetCurrentUser();
+        if (user is null) return Unauthorized();
+        var languages = await languageService.GetOwn(user.Id);
+        return Inertia.Render("Profile/Index", new {
+            User = user.ToDomain().ToDto(),
+            Languages = languages.Select(l => l.ToDto())
+        });
+    }
+
+    [Authorize]
+    [HttpGet("/profile/edit")]
+    public async Task<IActionResult> Edit() {
+        var user = await GetCurrentUser();
+        if (user is null) return Unauthorized();
+        return Inertia.Render("Profile/Edit", new {
+            User = user.ToDomain().ToDto()
+        });
+    }
+
+    public class EditRequest {
+        [Required(ErrorMessage = "Обязательное поле")]
+        public required string DisplayName { get; set; }
+    }
+
+    [Authorize]
+    [HttpPost("/profile/edit")]
+    public async Task<IActionResult> EditPost([FromForm] EditRequest request, IFormFile? avatar) {
+        var user = await GetCurrentUser();
+        if (user is null) return Unauthorized();
+
+        if (ModelState.IsValid) {
+            user.DisplayName = request.DisplayName;
+            await userManager.UpdateAsync(user);
+            if (avatar is not null) {
+                fileService.UploadAvatar(avatar, user.Id);
+            }
+            return Inertia.Location("/profile");
+        }
+
+        return Inertia.Render("Profile/Edit", new {
+            User = user.ToDomain().ToDto()
+        });
+    }
+
+    [HttpGet("/profile/{id:guid}")]
+    public async Task<IActionResult> View(Guid id) {
+        var user = await userManager.Users.FirstOrDefaultAsync(u => u.Id == id);
+        if (user is null) return NotFound();
+        var languages = await languageService.GetOwn(id);
+        return Inertia.Render("Profile/View", new {
+            User = user.ToDomain().ToDto(),
+            Languages = languages.Select(l => l.ToDto())
+        });
+    }
+
+    private Task<AppUser?> GetCurrentUser() {
+        var name = HttpContext.User.Identity?.Name;
+        return name is null
+            ? Task.FromResult<AppUser?>(null)
+            : userManager.Users.FirstOrDefaultAsync(u => u.UserName == name);
+    }
+}

--- a/Yordanew/Program.cs
+++ b/Yordanew/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddViteHelper(options => {
 builder.Services.AddScoped<FileService>();
 builder.Services.AddScoped<LanguageService>();
 builder.Services.AddScoped<DictionaryService>();
+builder.Services.AddScoped<AuthorService>();
 
 var app = builder.Build();
 

--- a/Yordanew/Services/AuthorService.cs
+++ b/Yordanew/Services/AuthorService.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Yordanew.Domain.Entity;
+using Yordanew.Models;
+
+namespace Yordanew.Services;
+
+public class AuthorService(UserManager<AppUser> userManager) {
+    public Task<Author?> GetById(Guid id) {
+        return userManager.Users
+            .Where(u => u.Id == id)
+            .Select(u => u.ToDomain())
+            .FirstOrDefaultAsync();
+    }
+
+    public Task<Author?> GetByName(string userName) {
+        return userManager.Users
+            .Where(u => u.UserName == userName)
+            .Select(u => u.ToDomain())
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<Author?> Update(Author author) {
+        var user = await userManager.FindByIdAsync(author.Id.ToString());
+        if (user is null) return null;
+        user.DisplayName = author.DisplayName;
+        await userManager.UpdateAsync(user);
+        return user.ToDomain();
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthorService for user domain operations
- register AuthorService in Program
- implement ProfileController with view/edit routes
- show self and other user profiles with languages
- add Vue pages for profile index, edit, and view

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861322e2cb4832e8d4372dce48c64da